### PR TITLE
Update webhook

### DIFF
--- a/horizon_config_EXAMPLE.ini
+++ b/horizon_config_EXAMPLE.ini
@@ -97,7 +97,7 @@ webhook_content = Outbound Trade:
 # 40 : ERROR
 # 50 : CRITICAL
 # Don't mess with this unless you know what you're doing.
-logging_level = 30
+logging_level = 20
 
 # Set to True to send a trade webhook on launch for each trade type you have enabled. If you have neither enabled, it won't send anything.
 testing = False
@@ -105,3 +105,6 @@ testing = False
 # This feature is experimental and may not work. This will hopefully prevent fake inbound trade notifications that are actually outbound trades.
 # This will cause an additional 10 second delay between detecting an inbound trade, and sending a webhook for it.
 double_check = True
+
+# Automatically checks for an update to Horizon every 60 minutes, and sends a discord webhook to one of your enabled trade types if an update is found. Set to False to disable.
+check_for_update = True

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ from utilities import (
     check_for_update_loop,
 )
 
-version = "v0.3.2-alpha"
+version = "v0.3.3-alpha"
 os.system("title " + f"Horizon {version}")
 
 logger = logging.getLogger("horizon.main")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+discord.py==1.7.1
 Pillow==8.2.0
-
 httpx==0.17.1

--- a/utilities.py
+++ b/utilities.py
@@ -21,7 +21,8 @@ import os
 import time
 
 # Third-Party
-from PIL import Image  # Actually using Pillow
+from discord import webhook, Webhook, Embed, utils
+from PIL import Image  # Pillow
 import httpx
 
 logger = logging.getLogger("horizon.utilities")
@@ -472,18 +473,164 @@ def format_text(text: str, trade_data: dict):
 
 
 async def check_for_update(current_version: str):
-    """Checks if provided current_version variable matches that of tag_name on the latest release GitHub API. Returns True if there is an update, False if there is not."""
+    """Checks if provided current_version variable matches that of tag_name on the latest release GitHub API. Returns the latest version tag if there is an update."""
     async with httpx.AsyncClient() as client:
-        logger.info("Checking for Horizon update")
+        logger.debug("Checking for Horizon update")
         request = await client.get(
             "https://api.github.com/repos/JartanFTW/Trade-Notifier/releases/latest"
         )
+        logger.info("Checked for Horizon update")
     if request.status_code == 200:
         if current_version != request.json()["tag_name"]:
-            return True
-        else:
-            return False
+            return request.json()["tag_name"]
     else:
         raise UnknownResponse(
             request.response_code, request.url, response_text=request.text
+        )
+
+
+async def check_for_update_loop(current_version: str, webhook_url: str = None):
+    """Checks for an update every 60 minutes, and if it finds one sends an alert to the webhook provided."""
+    while True:
+        update = await check_for_update(current_version)
+        if update:
+            print_timestamp(f"A new update is available! Version {update}")
+            logging.info(f"A new update is available! Version {update}")
+            if webhook_url:
+                async with httpx.AsyncClient() as client:
+                    webhook = Webhook.from_url(
+                        webhook_url, adapter=HttpxWebhookAdapter(client)
+                    )
+                    embed = Embed(
+                        title=f"Horizon Update {update} is available!",
+                        description="A new update for Horizon means added features, stability, and an overall nicer experience.",
+                        url="https://github.com/JartanFTW/Trade-Notifier/releases/latest",
+                        color=16294974,
+                    )
+                    w = await webhook.send(embed=embed)
+        await asyncio.sleep(7200)
+
+
+class HttpxWebhookAdapter(
+    webhook.WebhookAdapter
+):  # Adapted from discord.py AsyncWebhookAdapter to suit httpx & Horizon's needs.
+    """A webhook adapter suited for use with httpx.
+    .. note::
+        You are responsible for cleaning up the client session.
+    Parameters
+    -----------
+    session: :class:`httpx.AsyncClient`
+        The session to use to send requests.
+    """
+
+    def __init__(self, session):
+        self.session = session
+        self.loop = asyncio.get_event_loop()
+
+    def is_async(self):
+        return True
+
+    async def request(
+        self, verb, url, payload=None, multipart=None, *, files=None, reason=None
+    ):
+        headers = {}
+        data = None
+        files = files or []
+        if payload:
+            headers["Content-Type"] = "application/json"
+            data = utils.to_json(payload)
+
+        if reason:
+            headers["X-Audit-Log-Reason"] = _uriquote(reason, safe="/ ")
+
+        base_url = url.replace(self._request_url, "/") or "/"
+        _id = self._webhook_id
+        for tries in range(5):
+            for file in files:
+                file.reset(seek=tries)
+
+            attachments = None
+            if multipart:
+                data = {}
+                attachments = {}
+                for key, value in multipart.items():
+                    if key.startswith("file"):
+                        attachments[key] = (value[0], value[1], "multipart/form-data")
+                    else:
+                        data[key] = value
+
+            r = await self.session.request(
+                verb, url, headers=headers, data=data, files=attachments
+            )
+            r.status = r.status_code
+            r.reason = r.reason_phrase
+            logger.debug(
+                "Webhook ID %s with %s %s has returned status code %s",
+                _id,
+                verb,
+                base_url,
+                r.status_code,
+            )
+            # Coerce empty strings to return None for hygiene purposes
+            response = (r.text) or None
+            if r.headers["Content-Type"] == "application/json":
+                response = r.json()
+
+            # check if we have rate limit header information
+            remaining = r.headers.get("X-Ratelimit-Remaining")
+            if remaining == "0" and r.status != 429:
+                delta = utils._parse_ratelimit_header(r)
+                logger.debug(
+                    "Webhook ID %s has been pre-emptively rate limited, waiting %.2f seconds",
+                    _id,
+                    delta,
+                )
+                await asyncio.sleep(delta)
+
+            if 300 > r.status_code >= 200:
+                return response
+
+            # we are being rate limited
+            if r.status_code == 429:
+                if not r.headers.get("Via"):
+                    # Banned by Cloudflare more than likely.
+                    raise webhook.HTTPException(r, data)
+
+                retry_after = response["retry_after"] / 1000.0
+                logger.warning(
+                    "Webhook ID %s is rate limited. Retrying in %.2f seconds",
+                    _id,
+                    retry_after,
+                )
+                await asyncio.sleep(retry_after)
+                continue
+
+            if r.status_code in (500, 502):
+                await asyncio.sleep(1 + tries * 2)
+                continue
+
+            if r.status_code == 403:
+                raise webhook.Forbidden(r, response)
+            elif r.status_code == 404:
+                raise webhook.NotFound(r, response)
+            else:
+                raise webhook.HTTPException(r, response)
+
+        # no more retries
+        if r.status >= 500:
+            raise DiscordServerError(r, response)
+        raise webhook.HTTPException(r, response)
+
+    async def handle_execution_response(self, response, *, wait):
+        data = await response
+        if not wait:
+            return data
+
+        # transform into Message object
+        # Make sure to coerce the state to the partial one to allow message edits/delete
+        state = webhook._PartialWebhookState(
+            self, self.webhook, parent=self.webhook._state
+        )
+        return webhook.WebhookMessage(
+            data=data, state=state, channel=self.webhook.channel
         )

--- a/utilities.py
+++ b/utilities.py
@@ -221,6 +221,9 @@ def load_config(path: str):
     config["double_check"] = (
         True if str(parser["DEBUG"]["double_check"]).upper() == "TRUE" else False
     )
+    config["check_for_update"] = (
+        True if str(parser["DEBUG"]["check_for_update"]).upper() == "TRUE" else False
+    )
 
     return config
 


### PR DESCRIPTION
Implemented a new webhook system based on the discord.py system (it's ideal because I'd just be rewriting their code otherwise). This webhook system has been put into place for both regular notification webhooks and the new update notification webhooks too. On the surface users won't notice any difference but underneath it's way more adaptable for future expansions if we need them.
Added an automatic webhook notification that'll alert the user every two hours if there is an update available for Horizon. This will only send webhooks when enabled in the config under the debug section, and will prioritize sending to the webhook url for completed trades first, inbound second, and outbound last, depending on which ones are enabled.

closes #79